### PR TITLE
Fix failures caused by read-only configuration files

### DIFF
--- a/Westwind.Utilities.Configuration/Support/Utilities/SerializationUtils.cs
+++ b/Westwind.Utilities.Configuration/Support/Utilities/SerializationUtils.cs
@@ -303,7 +303,7 @@ namespace Westwind.Utilities
                     serializer = new XmlSerializer(objectType);
 
                     // A FileStream is needed to read the XML document.
-                    fs = new FileStream(fileName, FileMode.Open);
+                    fs = new FileStream(fileName, FileMode.Open, FileAccess.Read);
                     reader = new XmlTextReader(fs);
 
                     instance = serializer.Deserialize(reader);
@@ -334,7 +334,7 @@ namespace Westwind.Utilities
                 try
                 {
                     serializer = new BinaryFormatter();
-                    fs = new FileStream(fileName, FileMode.Open);
+                    fs = new FileStream(fileName, FileMode.Open, FileAccess.Read);
                     instance = serializer.Deserialize(fs);
 
                 }

--- a/Westwind.Utilities.Configuration/XmlFileConfigurationProvider.cs
+++ b/Westwind.Utilities.Configuration/XmlFileConfigurationProvider.cs
@@ -99,15 +99,14 @@ namespace Westwind.Utilities.Configuration
         /// </summary>
         /// <param name="config"></param>
         /// <returns></returns>
-        public override bool  Write(AppConfiguration config)
+        public override bool Write(AppConfiguration config)
         {
             EncryptFields(config);
             
             bool result = SerializationUtils.SerializeObject(config, XmlConfigurationFile, UseBinarySerialization);
             
-            if (result)
-                // Have to decrypt again to make sure the properties are readable afterwards
-                DecryptFields(config);
+            // Have to decrypt again to make sure the properties are readable afterwards
+            DecryptFields(config);
 
             return result;
  	    }


### PR DESCRIPTION
When a configuration file is read only, either due to file ownership or file permissions, the current behavior of the library is to throw. These changes ensure the in-memory configuration is still valid and the error is recoverable.

I didn't include the DLL file in the pull-request; but it needs to be recompiled. Hope you like the changes. Awesome library, by the way; I like the simplicity of the interface from the application side.
