### PR TITLE
Compile for Mono

### DIFF
--- a/Westwind.Utilities.Configuration/ConfigurationFileConfigurationProvider.cs
+++ b/Westwind.Utilities.Configuration/ConfigurationFileConfigurationProvider.cs
@@ -131,7 +131,7 @@ namespace Westwind.Utilities.Configuration
             // Loop through all fields and properties                 
             foreach (MemberInfo Member in Fields)
             {
-                string typeName = null;
+                //string typeName = null;
 
                 FieldInfo field = null;
                 PropertyInfo property = null;
@@ -141,13 +141,13 @@ namespace Westwind.Utilities.Configuration
                 {
                     field = (FieldInfo)Member;
                     fieldType = field.FieldType;
-                    typeName = fieldType.Name.ToLower();
+                    //typeName = fieldType.Name.ToLower();
                 }
                 else if (Member.MemberType == MemberTypes.Property)
                 {
                     property = (PropertyInfo)Member;
                     fieldType = property.PropertyType;
-                    typeName = fieldType.Name.ToLower();
+                    //typeName = fieldType.Name.ToLower();
                 }
                 else
                     continue;
@@ -248,19 +248,19 @@ namespace Westwind.Utilities.Configuration
                 FieldInfo Field = null;
                 PropertyInfo Property = null;
                 Type FieldType = null;
-                string TypeName = null;
+                //string TypeName = null;
 
                 if (Member.MemberType == MemberTypes.Field)
                 {
                     Field = (FieldInfo)Member;
                     FieldType = Field.FieldType;
-                    TypeName = Field.FieldType.Name.ToLower();
+                    //TypeName = Field.FieldType.Name.ToLower();
                 }
                 else if (Member.MemberType == MemberTypes.Property)
                 {
                     Property = (PropertyInfo)Member;
                     FieldType = Property.PropertyType;
-                    TypeName = Property.PropertyType.Name.ToLower();
+                    //TypeName = Property.PropertyType.Name.ToLower();
                 }
                 else
                     continue;

--- a/Westwind.Utilities.Configuration/PostBuildScript
+++ b/Westwind.Utilities.Configuration/PostBuildScript
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e          # crash on errors
+set -u          # crash on undefined variables
+set -o pipefail # crash when intermediate program in pipe fails
+
+# This script takes arguments in this form: variable="some value". Evaluate
+# those variables so they can be referenced in this script.
+while (( "$#" )); do
+  # Replace all backslashes in variable with forward slashes
+  # ${VARIABLE // MATCH / REPLACE }
+  #            ^--> replace all
+  eval ${1//\\/\/}
+  shift
+done
+
+cp -f $TargetPath               ../../../lib
+cp -f $TargetDir$TargetName.XML ../../../lib

--- a/Westwind.Utilities.Configuration/PostBuildScript.bat
+++ b/Westwind.Utilities.Configuration/PostBuildScript.bat
@@ -1,0 +1,16 @@
+@echo off
+setlocal
+
+:: Make sure git utilities precede windows utilities in the path
+set GitDir=C:\Program Files (x86)\Git\bin
+set Path=%GitDir%;%Path%
+
+:: Replace backslashes with forward slashes in the name of the script
+:: so that bash can extract the correct value for ${BASH_SOURCE[0]}
+set SCRIPT_NAME=%~dpn0
+set SCRIPT_NAME=%SCRIPT_NAME:\=/%
+
+bash.exe "%SCRIPT_NAME%" %*
+
+if ERRORLEVEL 9010 goto :EOF
+if ERRORLEVEL 9009 echo ERROR: bash not found. Install Git, which includes bash

--- a/Westwind.Utilities.Configuration/SqlServerConfigurationProvider.cs
+++ b/Westwind.Utilities.Configuration/SqlServerConfigurationProvider.cs
@@ -167,7 +167,7 @@ namespace Westwind.Utilities.Configuration
                         {
                             data.ExecuteNonQuery(sql);
                         }
-                        catch (Exception ex2)
+                        catch (Exception)
                         {
                             return null;
                         }

--- a/Westwind.Utilities.Configuration/Support/Data/SqlDataAccess.cs
+++ b/Westwind.Utilities.Configuration/Support/Data/SqlDataAccess.cs
@@ -357,7 +357,7 @@ namespace Westwind.Utilities.Data
                 Command.Parameters.Add(parameter);  
             }
 
-            DataTable dt = new DataTable(Tablename);
+            /* DataTable dt = */ new DataTable(Tablename);
 
             if (dataSet.Tables.Contains(Tablename))
                 dataSet.Tables.Remove(Tablename);

--- a/Westwind.Utilities.Configuration/Support/Utilities/Encryption.cs
+++ b/Westwind.Utilities.Configuration/Support/Utilities/Encryption.cs
@@ -315,7 +315,6 @@ namespace Westwind.Utilities
         /// <returns></returns>
         public static byte[] GZipMemory(string Filename, bool IsFile)
         {
-            string InputFile = Filename;
             byte[] Buffer = File.ReadAllBytes(Filename);
             return GZipMemory(Buffer);
         }
@@ -329,7 +328,6 @@ namespace Westwind.Utilities
         /// <returns></returns>
         public static bool GZipFile(string Filename, string OutputFile)
         {
-            string InputFile = Filename;
             byte[] Buffer = File.ReadAllBytes(Filename);
             FileStream fs = new FileStream(OutputFile, FileMode.OpenOrCreate, FileAccess.Write);
             GZipStream GZip = new GZipStream(fs, CompressionMode.Compress);

--- a/Westwind.Utilities.Configuration/Support/Utilities/ReflectionUtils.cs
+++ b/Westwind.Utilities.Configuration/Support/Utilities/ReflectionUtils.cs
@@ -233,7 +233,7 @@ namespace Westwind.Utilities
         /// <returns></returns>
         public static object GetPropertyEx(object Parent, string Property)
         {
-            Type type = Parent.GetType();
+            //Type type = Parent.GetType();
 
             int at = Property.IndexOf(".");
             if (at < 0)
@@ -263,7 +263,7 @@ namespace Westwind.Utilities
         /// <returns></returns>
         public static PropertyInfo GetPropertyInfoEx(object Parent, string Property)
         {
-            Type type = Parent.GetType();
+            //Type type = Parent.GetType();
 
             int at = Property.IndexOf(".");
             if (at < 0)
@@ -345,7 +345,7 @@ namespace Westwind.Utilities
         /// </param>
         public static object SetPropertyEx(object parent, string property, object value)
         {
-            Type Type = parent.GetType();
+            //Type Type = parent.GetType();
 
             // no more .s - we got our final object
             int lnAt = property.IndexOf(".");
@@ -433,7 +433,7 @@ namespace Westwind.Utilities
         /// <returns></returns>
         public static object CallMethodEx(object parent, string method, params object[] parms)
         {
-            Type Type = parent.GetType();
+            //Type Type = parent.GetType();
 
             // no more .s - we got our final object
             int lnAt = method.IndexOf(".");
@@ -881,7 +881,7 @@ namespace Westwind.Utilities
         public static object GetPropertyExCom(object parent, string property)
         {
 
-            Type Type = parent.GetType();
+            //Type Type = parent.GetType();
 
             int lnAt = property.IndexOf(".");
             if (lnAt < 0)
@@ -937,7 +937,7 @@ namespace Westwind.Utilities
         /// </param>
         public static object SetPropertyExCom(object parent, string property, object value)
         {
-            Type Type = parent.GetType();
+            //Type Type = parent.GetType();
 
             int lnAt = property.IndexOf(".");
             if (lnAt < 0)
@@ -982,7 +982,7 @@ namespace Westwind.Utilities
         /// <returns></returns>
         public static object CallMethodExCom(object parent, string method, params object[] parms)
         {
-            Type Type = parent.GetType();
+            //Type Type = parent.GetType();
 
             // no more .s - we got our final object
             int at = method.IndexOf(".");

--- a/Westwind.Utilities.Configuration/Westwind.Utilities.Configuration.csproj
+++ b/Westwind.Utilities.Configuration/Westwind.Utilities.Configuration.csproj
@@ -75,8 +75,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy $(TargetPath) ..\..\..\lib
-copy $(TargetDir)$(TargetName).xml ..\..\..\lib</PostBuildEvent>
+    <PostBuildEvent>$(ProjectDir)PostBuildScript TargetPath="$(TargetPath)" TargetDir="$(TargetDir)" TargetName="$(TargetName)"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Westwind.Utilities.Configuration/Westwind.Utilities.Configuration.csproj
+++ b/Westwind.Utilities.Configuration/Westwind.Utilities.Configuration.csproj
@@ -21,6 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Westwind.Utilities.Configuration.XML</DocumentationFile>
+    <NoWarn>1570 1572 1573 1574 1587 1591 1711</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +32,7 @@
     <WarningLevel>4</WarningLevel>
     <RegisterForComInterop>false</RegisterForComInterop>
     <DocumentationFile>bin\Release\Westwind.Utilities.Configuration.XML</DocumentationFile>
+    <NoWarn>1570 1572 1573 1574 1587 1591 1711</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Fix warnings that appear on Mono, and use a shell script to perform post-build step so it works with both Visual Studio and MonoDevelop.

I've been using your library on Mono and, in order to make it perform the post-build step I use a trick which may be too hacky for you to want to accept this pull request. Since I know the user has git installed (in order to check out this github repo), I write the PostBuildEvent step as a bash script, which works on Mac and Linux (because they have bash) and Windows (because git-bash is installed). I also fixed a number of compiler warnings, mostly by disabling them in the .csproj file.
