### PR TITLE
Fixed issue where existing XML config file would get overwritten if XML was not well-formed

### DIFF
--- a/Westwind.Utilities.Configuration/Providers/XmlFileConfigurationProvider.cs
+++ b/Westwind.Utilities.Configuration/Providers/XmlFileConfigurationProvider.cs
@@ -31,6 +31,7 @@
 */
 #endregion
 
+using System;
 namespace Westwind.Utilities.Configuration
 {
 
@@ -68,6 +69,12 @@ namespace Westwind.Utilities.Configuration
         public override bool Read(AppConfiguration config)
         {
             var newConfig = SerializationUtils.DeSerializeObject(XmlConfigurationFile,typeof(TAppConfiguration),UseBinarySerialization) as TAppConfiguration;
+
+
+            //If the file exists, but it could not be read (most likely due to badly formed XML), don't overwrite it.
+            if (System.IO.File.Exists(XmlConfigurationFile) == true && newConfig == null)
+                throw new Exception(string.Format("Config file {0} exists, but does not appear to contain well-formed XML. Please verify the XML contents of the file.", XmlConfigurationFile));
+
             if (newConfig == null)
             {
                 if(Write(config))


### PR DESCRIPTION
There is an issue in the XmlFileConfigurationProvider that would overwrite an existing XML file if the XML contents were not well-formed. 

The fix simply checks if the file exists, and if it does, rather than overwrite it (thereby throwing away any config that was stored in it), it throws an exception.
